### PR TITLE
Remove header passing from methods.

### DIFF
--- a/clustoapi/server.py
+++ b/clustoapi/server.py
@@ -410,9 +410,7 @@ Examples:
     drivers = bottle.request.params.getall('driver')
     children = bottle.request.params.get('children', default=True, type=bool)
     mode = bottle.request.headers.get('Clusto-Mode', default='compact')
-    headers = {
-        'Clusto-Minify': bottle.request.headers.get('Clusto-Minify', default='False')
-    }
+    headers = {}
 
     try:
         # Assignments are moved into the try block because of the int casting.
@@ -504,15 +502,11 @@ Examples:
 """
 
     driver = bottle.request.params.get('driver', default=None)
-    mode = bottle.request.headers.get('Clusto-Mode', default='expanded')
-    headers = {
-        'Clusto-Minify': bottle.request.headers.get('Clusto-Minify', default='False')
-    }
     obj, status, msg = util.get(name, driver)
     if not obj:
-        return util.dumps(msg, status, headers=headers)
+        return util.dumps(msg, status)
     try:
-        return util.dumps(util.show(obj, mode))
+        return util.dumps(util.show(obj))
     except TypeError as te:
         return util.dumps('%s' % (te,), 409)
 
@@ -608,9 +602,6 @@ Examples:
         return util.dumps('Provide at least one name to get data from', 412)
 
     mode = bottle.request.headers.get('Clusto-Mode', default='compact')
-    headers = {
-        'Clusto-Minify': bottle.request.headers.get('Clusto-Minify', default='False')
-    }
     for name in names:
         obj, status, msg = util.get(name)
         try:
@@ -618,7 +609,7 @@ Examples:
         except TypeError as te:
             return util.dumps('%s' % (te,), 409)
 
-    return util.dumps(objs, 200 if all(objs) else 206 if any(objs) else 404, headers=headers)
+    return util.dumps(objs, 200 if all(objs) else 206 if any(objs) else 404)
 
 
 @root_app.get('/by-attr')
@@ -704,16 +695,13 @@ Examples:
         return util.dumps('Provide a key to use get_by_attr', 412)
 
     mode = bottle.request.headers.get('Clusto-Mode', default='compact')
-    headers = {
-        'Clusto-Minify': bottle.request.headers.get('Clusto-Minify', default='False')
-    }
 
     try:
         ents = clusto.get_by_attr(**kwargs)
         results = []
         for ent in ents:
             results.append(util.show(ent, mode))
-        return util.dumps(results, headers=headers)
+        return util.dumps(results)
     except TypeError as te:
         return util.dumps('%s' % (te,), 409)
     except LookupError as le:

--- a/clustoapi/util.py
+++ b/clustoapi/util.py
@@ -49,7 +49,8 @@ Dumps a given object as a JSON string in an HTTP Response object.
 Will circumvent pretty-printing if Clusto-Minify header is True.
 """
     kwargs = {'sort_keys': True}
-    if headers.get('Clusto-Minify', 'False').lower() != 'true':
+    headers['Clusto-Minify'] = bottle.request.headers.get('Clusto-Minify', default='False')
+    if headers['Clusto-Minify'].lower() != 'true':
         kwargs['indent'] = 4
         kwargs['separators'] = (',', ': ')
 
@@ -81,10 +82,12 @@ JSON.
     return str(obj)
 
 
-def show(obj, mode='expanded'):
+def show(obj, mode=''):
     """
 Will return the expanded or compact representation of a given object
 """
+    if not mode:
+        mode = bottle.request.headers.get('Clusto-Mode', default='expanded')
 
     def compact():
         return u'/%s/%s' % (obj.driver, obj.name)


### PR DESCRIPTION
This pushes the header parsing for both ``Mode`` and ``Minify`` into their respective methods so that we don't have to replicate it for every method.

To override defaults, we just have to make the same bottle header request, but with a different default.