### PR TITLE
The routes are matched per app

### DIFF
--- a/tests/suites/util.py
+++ b/tests/suites/util.py
@@ -60,7 +60,6 @@ class TestingServer(threading.Thread):
                 'apps': get_mount_apps(),
                 'server': self.server,
                 'response_headers': {'Access-Control-Allow-Origin': '*'},
-                'enable_options_method': True,
             },
             configfile=conffile,
             init_data={


### PR DESCRIPTION
That is, the main app's routes don't match the mounted apps' routes.
Plugging a new route per mounted application feels like the less
intrusive / cleaner change right now.

This allows me to move the documentation endpoints back per-mounted
application as they were intended to be, which is nice.

A few text formatting changes as well, and some cosmetic cleanup.